### PR TITLE
Prevent unauthorized message fallbacks and menu exploits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,104 @@
-# nexojoin
+# NexoJoin
+
+NexoJoin is a Spigot/Paper plugin for Minecraft 1.21+ that allows players to choose their own join and leave messages from a GUI menu. Server owners can define as many message styles as they like in the configuration file and gate each one behind a permission node.
+
+## Features
+
+- `/joinmessages` (`/messages`) opens an intuitive menu where players can switch between join and leave message selectors.
+- Fully configurable join and leave messages with color codes (`&`), `%player%`, and `%displayname%` placeholders.
+- Optional permission node per message so you can grant access through your ranks system.
+- Player selections are saved in `plugins/NexoJoin/players.yml`.
+- `/joinmessages reload` lets administrators reload the configuration without restarting the server.
+
+## How the plugin works
+
+1. Define the join and leave message styles you want to offer inside `config.yml`, optionally attaching a permission string to each option.
+2. Grant the appropriate permissions (for example through LuckPerms or another ranks plugin) so that players only see and select the styles they are entitled to use.
+3. Players execute `/joinmessages` to open a two-step GUI: the root menu lets them choose between join or leave selectors, and the selection menu displays the permitted styles with previews and lore.
+4. When a player picks a style, NexoJoin stores their selection in `players.yml`. On subsequent joins or quits the plugin re-validates the stored selection, automatically clearing it if they lose permission and falling back to an allowed default instead of an unrestricted option.
+
+These safeguards ensure players cannot exploit the system to force messages they have not been granted, even if the configuration changes while they are offline.
+
+## Permissions
+
+- `nexojoin.command` – allows players to open the selector menu. (default: `true`)
+- `nexojoin.reload` – reloads the plugin configuration. (default: `op`)
+- Any additional permission strings that you add to message definitions will be required for players to use those specific messages.
+
+## Configuration
+
+The default `config.yml` includes example messages. Add new entries under `join-messages` or `leave-messages`, specifying a unique key, display name, message text, material icon, lore, and optional permission. All text fields support the standard legacy ampersand color/style codes (for example `&6` for gold, `&l` for bold) along with the `%player%` and `%displayname%` placeholders.
+
+```yml
+join-messages:
+  sparkles:
+    display-name: "&dSparkly Arrival"
+    message: "&d%player% &7appeared in a flash of light!"
+    material: "FIREWORK_ROCKET"
+    permission: "nexojoin.join.sparkles"
+```
+
+Set the defaults via the `defaults.join` and `defaults.leave` values. Players without a saved selection will be assigned the default as long as they have the permission for it.
+
+### Menu layout
+
+The `menu` section controls the GUI layout:
+
+```yml
+menu:
+  root:
+    title: "&9Nexo Messages"
+    size: 27              # Must be a multiple of 9 (min 9, max 54)
+    items:
+      join:
+        slot: 11          # Slot indices follow the standard chest grid (0-53)
+        material: "LIME_DYE"
+        name: "&aJoin Messages"
+        lore:
+          - "&7Select your join message."
+      leave:
+        slot: 15
+        material: "RED_DYE"
+        name: "&cLeave Messages"
+        lore:
+          - "&7Select your leave message."
+  selection:
+    size: 54
+    option-slots:         # Optional ordering for message buttons
+      - 10
+      - 11
+      - 12
+      - 19
+      - 20
+      - 21
+      - 28
+      - 29
+      - 30
+      - 37
+      - 38
+      - 39
+    join:
+      title: "&aJoin Messages"
+    leave:
+      title: "&cLeave Messages"
+    back-item:
+      slot: 49
+      material: "ARROW"
+      name: "&cBack"
+      lore:
+        - "&7Click to return to the main menu."
+    empty:
+      slot: 22
+      material: "BARRIER"
+      name: "&cNo messages available"
+      lore:
+        - "&7You do not have access to any messages."
+```
+
+- `root.size` and `selection.size` are clamped to valid multiples of 9 between 9 and 54 slots.
+- Every slot index is validated; if a configured slot is outside the menu size it will be skipped and a warning will be written to console.
+- `option-slots` lets you dictate the order and placement of message buttons; if you omit it the plugin fills the first available slots automatically.
+
+## Building
+
+The project uses Maven. Run `mvn package` to build `target/NexoJoin-1.0.0-shaded.jar`.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,59 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>me.minimize</groupId>
+    <artifactId>NexoJoin</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <name>NexoJoin</name>
+    <description>Custom join and leave messages with menu selection.</description>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <spigot.api.version>1.21.1-R0.1-SNAPSHOT</spigot.api.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>${spigot.api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
+                    <release>${maven.compiler.source}</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/me/minimize/NexoJoin/MessageManager.java
+++ b/src/main/java/me/minimize/NexoJoin/MessageManager.java
@@ -1,0 +1,131 @@
+package me.minimize.NexoJoin;
+
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.logging.Logger;
+
+public class MessageManager {
+    private final NexoJoinPlugin plugin;
+    private final Map<MessageType, Map<String, MessageOption>> options = new EnumMap<>(MessageType.class);
+    private final Map<MessageType, String> defaultOptions = new EnumMap<>(MessageType.class);
+
+    public MessageManager(NexoJoinPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public void load() {
+        options.clear();
+        defaultOptions.clear();
+
+        FileConfiguration config = plugin.getConfig();
+        Logger logger = plugin.getLogger();
+
+        for (MessageType type : MessageType.values()) {
+            ConfigurationSection section = config.getConfigurationSection(type.getConfigKey());
+            Map<String, MessageOption> typeOptions = new LinkedHashMap<>();
+
+            if (section == null) {
+                logger.warning("No configuration section found for " + type.getConfigKey());
+            } else {
+                for (String id : section.getKeys(false)) {
+                    ConfigurationSection optionSection = section.getConfigurationSection(id);
+                    if (optionSection == null) {
+                        continue;
+                    }
+
+                    String displayName = optionSection.getString("display-name", id);
+                    String message = optionSection.getString("message", "");
+                    String permission = optionSection.getString("permission", "");
+                    String materialName = optionSection.getString("material", "PAPER");
+                    List<String> lore = optionSection.getStringList("lore");
+
+                    Material material = Material.matchMaterial(materialName.toUpperCase(Locale.ROOT));
+                    if (material == null) {
+                        logger.warning("Invalid material '" + materialName + "' for option '" + id + "' in " + type.getConfigKey() + ". Using PAPER.");
+                        material = Material.PAPER;
+                    }
+
+                    MessageOption option = new MessageOption(id, displayName, message, permission, material, lore);
+                    typeOptions.put(id, option);
+                }
+            }
+
+            if (typeOptions.isEmpty()) {
+                logger.warning("No message options defined for " + type.name().toLowerCase(Locale.ROOT) + ".");
+            }
+
+            options.put(type, typeOptions);
+
+            String defaultId = config.getString("defaults." + type.getStorageKey());
+            if (defaultId == null || !typeOptions.containsKey(defaultId)) {
+                if (defaultId != null) {
+                    logger.warning("Default option '" + defaultId + "' for " + type.name().toLowerCase(Locale.ROOT) + " not found. Using the first available option.");
+                }
+                defaultId = typeOptions.keySet().stream().findFirst().orElse(null);
+            }
+            defaultOptions.put(type, defaultId);
+        }
+    }
+
+    public Map<String, MessageOption> getOptions(MessageType type) {
+        Map<String, MessageOption> typeOptions = options.get(type);
+        return typeOptions == null ? Collections.emptyMap() : Collections.unmodifiableMap(typeOptions);
+    }
+
+    public MessageOption getOption(MessageType type, String id) {
+        Map<String, MessageOption> typeOptions = options.get(type);
+        if (typeOptions == null) {
+            return null;
+        }
+        return typeOptions.get(id);
+    }
+
+    public String getDefaultId(MessageType type) {
+        return defaultOptions.get(type);
+    }
+
+    public MessageOption getDefault(MessageType type) {
+        String id = getDefaultId(type);
+        if (id == null) {
+            return null;
+        }
+        return getOption(type, id);
+    }
+
+    public MessageOption getFirstAvailable(Player player, MessageType type) {
+        Map<String, MessageOption> typeOptions = options.get(type);
+        if (typeOptions == null || typeOptions.isEmpty()) {
+            return null;
+        }
+        for (MessageOption option : typeOptions.values()) {
+            if (option.canUse(player)) {
+                return option;
+            }
+        }
+        return null;
+    }
+
+    public List<MessageOption> getAvailable(Player player, MessageType type) {
+        Map<String, MessageOption> typeOptions = options.get(type);
+        if (typeOptions == null || typeOptions.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<MessageOption> result = new ArrayList<>();
+        for (MessageOption option : typeOptions.values()) {
+            if (option.canUse(player)) {
+                result.add(option);
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/me/minimize/NexoJoin/MessageOption.java
+++ b/src/main/java/me/minimize/NexoJoin/MessageOption.java
@@ -1,0 +1,101 @@
+package me.minimize.NexoJoin;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+public class MessageOption {
+    private static final LegacyComponentSerializer LEGACY_SERIALIZER = LegacyComponentSerializer.legacyAmpersand();
+
+    private final String id;
+    private final String displayName;
+    private final String message;
+    private final String permission;
+    private final Material material;
+    private final List<String> lore;
+
+    public MessageOption(String id, String displayName, String message, String permission, Material material, List<String> lore) {
+        this.id = Objects.requireNonNull(id, "id");
+        this.displayName = displayName == null ? id : displayName;
+        this.message = message == null ? "" : message;
+        this.permission = permission == null ? "" : permission;
+        this.material = material == null ? Material.PAPER : material;
+        this.lore = lore == null ? Collections.emptyList() : new ArrayList<>(lore);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getPermission() {
+        return permission;
+    }
+
+    public Material getMaterial() {
+        return material;
+    }
+
+    public List<String> getLore() {
+        return Collections.unmodifiableList(lore);
+    }
+
+    public boolean canUse(Player player) {
+        return permission.isEmpty() || player.hasPermission(permission);
+    }
+
+    public Component asDisplayComponent() {
+        return LEGACY_SERIALIZER.deserialize(displayName);
+    }
+
+    public List<Component> buildLore(boolean selected) {
+        List<Component> components = new ArrayList<>();
+        for (String line : lore) {
+            components.add(LEGACY_SERIALIZER.deserialize(line));
+        }
+        if (!message.isEmpty()) {
+            if (!components.isEmpty()) {
+                components.add(Component.empty());
+            }
+            components.add(LEGACY_SERIALIZER.deserialize("&7Preview:"));
+            components.add(LEGACY_SERIALIZER.deserialize("&f" + message.replace("%player%", "Player").replace("%displayname%", "Player")));
+        }
+        if (selected) {
+            if (!components.isEmpty()) {
+                components.add(Component.empty());
+            }
+            components.add(LEGACY_SERIALIZER.deserialize("&aCurrently selected"));
+        }
+        if (!permission.isEmpty()) {
+            if (!components.isEmpty()) {
+                components.add(Component.empty());
+            }
+            components.add(LEGACY_SERIALIZER.deserialize("&7Permission: &f" + permission.toLowerCase(Locale.ROOT)));
+        }
+        return components;
+    }
+
+    public Component formatMessage(Player player) {
+        if (message.isEmpty()) {
+            return Component.empty();
+        }
+        String formatted = message
+                .replace("%player%", player.getName())
+                .replace("%displayname%", player.getDisplayName());
+        return LEGACY_SERIALIZER.deserialize(formatted);
+    }
+}

--- a/src/main/java/me/minimize/NexoJoin/MessageType.java
+++ b/src/main/java/me/minimize/NexoJoin/MessageType.java
@@ -1,0 +1,22 @@
+package me.minimize.NexoJoin;
+
+public enum MessageType {
+    JOIN("join-messages", "join"),
+    LEAVE("leave-messages", "leave");
+
+    private final String configKey;
+    private final String storageKey;
+
+    MessageType(String configKey, String storageKey) {
+        this.configKey = configKey;
+        this.storageKey = storageKey;
+    }
+
+    public String getConfigKey() {
+        return configKey;
+    }
+
+    public String getStorageKey() {
+        return storageKey;
+    }
+}

--- a/src/main/java/me/minimize/NexoJoin/NexoJoinPlugin.java
+++ b/src/main/java/me/minimize/NexoJoin/NexoJoinPlugin.java
@@ -1,0 +1,45 @@
+package me.minimize.NexoJoin;
+
+import me.minimize.NexoJoin.command.JoinMessageCommand;
+import me.minimize.NexoJoin.listener.JoinQuitListener;
+import me.minimize.NexoJoin.menu.MenuListener;
+import me.minimize.NexoJoin.menu.MenuService;
+import org.bukkit.Bukkit;
+import org.bukkit.command.PluginCommand;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class NexoJoinPlugin extends JavaPlugin {
+    private MessageManager messageManager;
+    private PlayerDataManager playerDataManager;
+    private MenuService menuService;
+
+    @Override
+    public void onEnable() {
+        saveDefaultConfig();
+
+        messageManager = new MessageManager(this);
+        messageManager.load();
+
+        playerDataManager = new PlayerDataManager(this, messageManager);
+        menuService = new MenuService(this, messageManager, playerDataManager);
+
+        PluginCommand command = getCommand("joinmessages");
+        if (command != null) {
+            JoinMessageCommand joinMessageCommand = new JoinMessageCommand(this, menuService, messageManager);
+            command.setExecutor(joinMessageCommand);
+            command.setTabCompleter(joinMessageCommand);
+        } else {
+            getLogger().warning("joinmessages command is not defined in plugin.yml");
+        }
+
+        Bukkit.getPluginManager().registerEvents(new MenuListener(menuService, messageManager, playerDataManager), this);
+        Bukkit.getPluginManager().registerEvents(new JoinQuitListener(messageManager, playerDataManager), this);
+    }
+
+    @Override
+    public void onDisable() {
+        if (playerDataManager != null) {
+            playerDataManager.save();
+        }
+    }
+}

--- a/src/main/java/me/minimize/NexoJoin/PlayerDataManager.java
+++ b/src/main/java/me/minimize/NexoJoin/PlayerDataManager.java
@@ -1,0 +1,67 @@
+package me.minimize.NexoJoin;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+import java.util.logging.Level;
+
+public class PlayerDataManager {
+    private final NexoJoinPlugin plugin;
+    private final MessageManager messageManager;
+    private final File dataFile;
+    private YamlConfiguration dataConfiguration;
+
+    public PlayerDataManager(NexoJoinPlugin plugin, MessageManager messageManager) {
+        this.plugin = plugin;
+        this.messageManager = messageManager;
+        this.dataFile = new File(plugin.getDataFolder(), "players.yml");
+        reload();
+    }
+
+    public void reload() {
+        if (!dataFile.exists()) {
+            try {
+                File parent = dataFile.getParentFile();
+                if (parent != null && !parent.exists()) {
+                    parent.mkdirs();
+                }
+                dataFile.createNewFile();
+            } catch (IOException e) {
+                plugin.getLogger().log(Level.SEVERE, "Could not create players.yml", e);
+            }
+        }
+        dataConfiguration = YamlConfiguration.loadConfiguration(dataFile);
+    }
+
+    public void save() {
+        try {
+            dataConfiguration.save(dataFile);
+        } catch (IOException e) {
+            plugin.getLogger().log(Level.SEVERE, "Could not save players.yml", e);
+        }
+    }
+
+    public String getSelectedMessageId(UUID uuid, MessageType type) {
+        return dataConfiguration.getString(uuid.toString() + "." + type.getStorageKey());
+    }
+
+    public MessageOption getSelectedOption(UUID uuid, MessageType type) {
+        String id = getSelectedMessageId(uuid, type);
+        if (id == null) {
+            return null;
+        }
+        return messageManager.getOption(type, id);
+    }
+
+    public void setSelection(UUID uuid, MessageType type, String id) {
+        String path = uuid.toString() + "." + type.getStorageKey();
+        if (id == null || id.isEmpty()) {
+            dataConfiguration.set(path, null);
+        } else {
+            dataConfiguration.set(path, id);
+        }
+        save();
+    }
+}

--- a/src/main/java/me/minimize/NexoJoin/command/JoinMessageCommand.java
+++ b/src/main/java/me/minimize/NexoJoin/command/JoinMessageCommand.java
@@ -1,0 +1,65 @@
+package me.minimize.NexoJoin.command;
+
+import me.minimize.NexoJoin.MessageManager;
+import me.minimize.NexoJoin.NexoJoinPlugin;
+import me.minimize.NexoJoin.menu.MenuService;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+
+public class JoinMessageCommand implements CommandExecutor, TabCompleter {
+    private static final LegacyComponentSerializer LEGACY_SERIALIZER = LegacyComponentSerializer.legacyAmpersand();
+
+    private final NexoJoinPlugin plugin;
+    private final MenuService menuService;
+    private final MessageManager messageManager;
+
+    public JoinMessageCommand(NexoJoinPlugin plugin, MenuService menuService, MessageManager messageManager) {
+        this.plugin = plugin;
+        this.menuService = menuService;
+        this.messageManager = messageManager;
+    }
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (args.length > 0 && args[0].equalsIgnoreCase("reload")) {
+            if (!sender.hasPermission("nexojoin.reload")) {
+                sender.sendMessage(LEGACY_SERIALIZER.deserialize("&cYou do not have permission to do that."));
+                return true;
+            }
+            plugin.reloadConfig();
+            messageManager.load();
+            sender.sendMessage(LEGACY_SERIALIZER.deserialize("&aNexoJoin configuration reloaded."));
+            return true;
+        }
+
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(LEGACY_SERIALIZER.deserialize("&cOnly players can use this command."));
+            return true;
+        }
+
+        if (!player.hasPermission("nexojoin.command")) {
+            sender.sendMessage(LEGACY_SERIALIZER.deserialize("&cYou do not have permission to use this command."));
+            return true;
+        }
+
+        menuService.openRootMenu(player);
+        return true;
+    }
+
+    @Override
+    public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String[] args) {
+        if (args.length == 1 && sender.hasPermission("nexojoin.reload")) {
+            return Collections.singletonList("reload");
+        }
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/me/minimize/NexoJoin/listener/JoinQuitListener.java
+++ b/src/main/java/me/minimize/NexoJoin/listener/JoinQuitListener.java
@@ -1,0 +1,72 @@
+package me.minimize.NexoJoin.listener;
+
+import me.minimize.NexoJoin.MessageManager;
+import me.minimize.NexoJoin.MessageOption;
+import me.minimize.NexoJoin.MessageType;
+import me.minimize.NexoJoin.PlayerDataManager;
+import net.kyori.adventure.text.Component;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+public class JoinQuitListener implements Listener {
+    private final MessageManager messageManager;
+    private final PlayerDataManager playerDataManager;
+
+    public JoinQuitListener(MessageManager messageManager, PlayerDataManager playerDataManager) {
+        this.messageManager = messageManager;
+        this.playerDataManager = playerDataManager;
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        Player player = event.getPlayer();
+        MessageOption option = resolveOption(player, MessageType.JOIN);
+        if (option == null) {
+            return;
+        }
+        if (option.getMessage().isEmpty()) {
+            event.joinMessage((Component) null);
+            return;
+        }
+        event.joinMessage(option.formatMessage(player));
+    }
+
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        Player player = event.getPlayer();
+        MessageOption option = resolveOption(player, MessageType.LEAVE);
+        if (option == null) {
+            return;
+        }
+        if (option.getMessage().isEmpty()) {
+            event.quitMessage((Component) null);
+            return;
+        }
+        event.quitMessage(option.formatMessage(player));
+    }
+
+    private MessageOption resolveOption(Player player, MessageType type) {
+        MessageOption option = playerDataManager.getSelectedOption(player.getUniqueId(), type);
+        if (option != null && option.canUse(player)) {
+            return option;
+        }
+        if (option != null) {
+            playerDataManager.setSelection(player.getUniqueId(), type, null);
+        }
+
+        MessageOption defaultOption = messageManager.getDefault(type);
+        if (defaultOption != null && defaultOption.canUse(player)) {
+            playerDataManager.setSelection(player.getUniqueId(), type, defaultOption.getId());
+            return defaultOption;
+        }
+
+        MessageOption fallback = messageManager.getFirstAvailable(player, type);
+        if (fallback != null) {
+            playerDataManager.setSelection(player.getUniqueId(), type, fallback.getId());
+        }
+        return fallback;
+    }
+}

--- a/src/main/java/me/minimize/NexoJoin/menu/MenuHolder.java
+++ b/src/main/java/me/minimize/NexoJoin/menu/MenuHolder.java
@@ -1,0 +1,32 @@
+package me.minimize.NexoJoin.menu;
+
+import me.minimize.NexoJoin.MessageType;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nullable;
+
+public class MenuHolder implements InventoryHolder {
+    private final MenuView view;
+    private final MessageType messageType;
+
+    public MenuHolder(MenuView view, @Nullable MessageType messageType) {
+        this.view = view;
+        this.messageType = messageType;
+    }
+
+    public MenuView getView() {
+        return view;
+    }
+
+    @Nullable
+    public MessageType getMessageType() {
+        return messageType;
+    }
+
+    @Override
+    public @NotNull Inventory getInventory() {
+        throw new UnsupportedOperationException("Menu inventories are managed directly");
+    }
+}

--- a/src/main/java/me/minimize/NexoJoin/menu/MenuListener.java
+++ b/src/main/java/me/minimize/NexoJoin/menu/MenuListener.java
@@ -1,0 +1,110 @@
+package me.minimize.NexoJoin.menu;
+
+import me.minimize.NexoJoin.MessageManager;
+import me.minimize.NexoJoin.MessageOption;
+import me.minimize.NexoJoin.MessageType;
+import me.minimize.NexoJoin.PlayerDataManager;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+public class MenuListener implements Listener {
+    private static final LegacyComponentSerializer LEGACY_SERIALIZER = LegacyComponentSerializer.legacyAmpersand();
+
+    private final MenuService menuService;
+    private final MessageManager messageManager;
+    private final PlayerDataManager playerDataManager;
+
+    public MenuListener(MenuService menuService, MessageManager messageManager, PlayerDataManager playerDataManager) {
+        this.menuService = menuService;
+        this.messageManager = messageManager;
+        this.playerDataManager = playerDataManager;
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        Inventory inventory = event.getInventory();
+        if (!(inventory.getHolder() instanceof MenuHolder holder)) {
+            return;
+        }
+
+        event.setCancelled(true);
+
+        ItemStack clicked = event.getCurrentItem();
+        if (clicked == null || clicked.getItemMeta() == null) {
+            return;
+        }
+
+        Player player = (Player) event.getWhoClicked();
+        ItemMeta meta = clicked.getItemMeta();
+        PersistentDataContainer container = meta.getPersistentDataContainer();
+
+        String action = container.get(menuService.getActionKey(), PersistentDataType.STRING);
+        if (action != null) {
+            handleAction(player, holder, action);
+            return;
+        }
+
+        if (holder.getView() != MenuView.SELECTION || holder.getMessageType() == null) {
+            return;
+        }
+
+        String optionId = container.get(menuService.getOptionKey(), PersistentDataType.STRING);
+        if (optionId == null) {
+            return;
+        }
+
+        MessageType type = holder.getMessageType();
+        MessageOption option = messageManager.getOption(type, optionId);
+        if (option == null) {
+            player.sendMessage(LEGACY_SERIALIZER.deserialize("&cThat message option is no longer available."));
+            menuService.refreshSelectionMenu(player, type);
+            return;
+        }
+
+        if (!option.canUse(player)) {
+            player.sendMessage(LEGACY_SERIALIZER.deserialize("&cYou do not have permission to use this message."));
+            return;
+        }
+
+        playerDataManager.setSelection(player.getUniqueId(), type, option.getId());
+        player.sendMessage(LEGACY_SERIALIZER.deserialize((type == MessageType.JOIN ? "&aSelected join message: " : "&aSelected leave message: ") + option.getDisplayName()));
+        menuService.refreshSelectionMenu(player, type);
+    }
+
+    @EventHandler
+    public void onInventoryDrag(InventoryDragEvent event) {
+        Inventory inventory = event.getView().getTopInventory();
+        if (!(inventory.getHolder() instanceof MenuHolder)) {
+            return;
+        }
+
+        event.setCancelled(true);
+    }
+
+    private void handleAction(Player player, MenuHolder holder, String action) {
+        if (action.equalsIgnoreCase("back")) {
+            menuService.openRootMenu(player);
+            return;
+        }
+
+        if (!action.startsWith("open:")) {
+            return;
+        }
+
+        String typeName = action.substring("open:".length());
+        try {
+            MessageType type = MessageType.valueOf(typeName);
+            menuService.openSelectionMenu(player, type);
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+}

--- a/src/main/java/me/minimize/NexoJoin/menu/MenuService.java
+++ b/src/main/java/me/minimize/NexoJoin/menu/MenuService.java
@@ -1,0 +1,417 @@
+package me.minimize.NexoJoin.menu;
+
+import me.minimize.NexoJoin.MessageManager;
+import me.minimize.NexoJoin.MessageOption;
+import me.minimize.NexoJoin.MessageType;
+import me.minimize.NexoJoin.NexoJoinPlugin;
+import me.minimize.NexoJoin.PlayerDataManager;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.logging.Logger;
+
+public class MenuService {
+    private static final LegacyComponentSerializer LEGACY_SERIALIZER = LegacyComponentSerializer.legacyAmpersand();
+
+    private final NexoJoinPlugin plugin;
+    private final MessageManager messageManager;
+    private final PlayerDataManager playerDataManager;
+    private final NamespacedKey optionKey;
+    private final NamespacedKey actionKey;
+    private final Logger logger;
+
+    public MenuService(NexoJoinPlugin plugin, MessageManager messageManager, PlayerDataManager playerDataManager) {
+        this.plugin = plugin;
+        this.messageManager = messageManager;
+        this.playerDataManager = playerDataManager;
+        this.optionKey = new NamespacedKey(plugin, "message-option");
+        this.actionKey = new NamespacedKey(plugin, "menu-action");
+        this.logger = plugin.getLogger();
+    }
+
+    public NamespacedKey getOptionKey() {
+        return optionKey;
+    }
+
+    public NamespacedKey getActionKey() {
+        return actionKey;
+    }
+
+    public void openRootMenu(Player player) {
+        ConfigurationSection rootSection = plugin.getConfig().getConfigurationSection("menu.root");
+        int size = resolveInventorySize(rootSection, 27);
+        String title = getString(rootSection, "title", "Messages");
+        Inventory inventory = Bukkit.createInventory(new MenuHolder(MenuView.ROOT, null), size, LEGACY_SERIALIZER.deserialize(title));
+
+        ConfigurationSection itemsSection = rootSection == null ? null : rootSection.getConfigurationSection("items");
+
+        ItemStack joinItem = createConfiguredMenuItem(
+                itemsSection == null ? null : itemsSection.getConfigurationSection("join"),
+                "menu.root.items.join",
+                Material.LIME_DYE,
+                getString(rootSection, "join-title", "Join Messages"),
+                List.of("&7Select your join message."));
+        ItemStack leaveItem = createConfiguredMenuItem(
+                itemsSection == null ? null : itemsSection.getConfigurationSection("leave"),
+                "menu.root.items.leave",
+                Material.RED_DYE,
+                getString(rootSection, "leave-title", "Leave Messages"),
+                List.of("&7Select your leave message."));
+
+        applyAction(joinItem, "open:JOIN");
+        applyAction(leaveItem, "open:LEAVE");
+
+        Set<Integer> usedSlots = new HashSet<>();
+
+        int joinSlot = resolveItemSlot(size, itemsSection, "join", 11, usedSlots);
+        if (joinSlot >= 0) {
+            usedSlots.add(joinSlot);
+            inventory.setItem(joinSlot, joinItem);
+        }
+
+        int leaveSlot = resolveItemSlot(size, itemsSection, "leave", 15, usedSlots);
+        if (leaveSlot >= 0) {
+            usedSlots.add(leaveSlot);
+            inventory.setItem(leaveSlot, leaveItem);
+        }
+
+        player.openInventory(inventory);
+    }
+
+    public void openSelectionMenu(Player player, MessageType type) {
+        ConfigurationSection selectionSection = plugin.getConfig().getConfigurationSection("menu.selection");
+        int size = resolveInventorySize(selectionSection, 54);
+        String titleKey = type == MessageType.JOIN ? "join.title" : "leave.title";
+        String fallbackTitle = type == MessageType.JOIN ? "Join Messages" : "Leave Messages";
+        String title = getString(selectionSection, titleKey, fallbackTitle);
+        Inventory inventory = Bukkit.createInventory(new MenuHolder(MenuView.SELECTION, type), size, LEGACY_SERIALIZER.deserialize(title));
+
+        int backSlot = resolveSlot(selectionSection, size, "back-item.slot", size - 1);
+        int emptySlot = resolveSlot(selectionSection, size, "empty.slot", 22);
+
+        List<MessageOption> options = messageManager.getAvailable(player, type);
+        String selectedId = playerDataManager.getSelectedMessageId(player.getUniqueId(), type);
+        boolean hasSelection = selectedId != null && options.stream().anyMatch(option -> option.getId().equalsIgnoreCase(selectedId));
+        if (!hasSelection) {
+            if (!options.isEmpty()) {
+                MessageOption first = options.get(0);
+                selectedId = first.getId();
+                playerDataManager.setSelection(player.getUniqueId(), type, selectedId);
+            } else if (selectedId != null) {
+                playerDataManager.setSelection(player.getUniqueId(), type, null);
+                selectedId = null;
+            }
+        }
+
+        List<Integer> configuredSlots = getConfiguredSlots(selectionSection);
+        Set<Integer> reservedSlots = new HashSet<>();
+        if (backSlot >= 0) {
+            reservedSlots.add(backSlot);
+        }
+        if (emptySlot >= 0) {
+            reservedSlots.add(emptySlot);
+        }
+
+        Set<Integer> usedSlots = new HashSet<>();
+        int optionIndex = 0;
+        for (MessageOption option : options) {
+            ItemStack item = new ItemStack(option.getMaterial());
+            ItemMeta meta = item.getItemMeta();
+            boolean selected = option.getId().equalsIgnoreCase(selectedId);
+            meta.displayName(option.asDisplayComponent());
+            meta.lore(option.buildLore(selected));
+            if (selected) {
+                meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+                meta.addEnchant(org.bukkit.enchantments.Enchantment.UNBREAKING, 1, true);
+            }
+            meta.getPersistentDataContainer().set(optionKey, PersistentDataType.STRING, option.getId());
+            item.setItemMeta(meta);
+
+            int slot = resolveOptionSlot(optionIndex++, configuredSlots, size, usedSlots, reservedSlots);
+            if (slot >= 0) {
+                usedSlots.add(slot);
+                inventory.setItem(slot, item);
+            }
+        }
+
+        if (options.isEmpty() && emptySlot >= 0) {
+            ItemStack placeholder = createEmptyPlaceholder(selectionSection);
+            inventory.setItem(emptySlot, placeholder);
+        }
+
+        ItemStack backItem = createBackItem(selectionSection);
+        applyAction(backItem, "back");
+        if (backSlot >= 0) {
+            inventory.setItem(backSlot, backItem);
+        }
+
+        player.openInventory(inventory);
+    }
+
+    public void refreshSelectionMenu(Player player, MessageType type) {
+        if (!(player.getOpenInventory().getTopInventory().getHolder() instanceof MenuHolder holder)) {
+            return;
+        }
+        if (holder.getView() != MenuView.SELECTION || holder.getMessageType() != type) {
+            return;
+        }
+        openSelectionMenu(player, type);
+    }
+
+    private ItemStack createConfiguredMenuItem(ConfigurationSection itemSection, String path, Material defaultMaterial, String defaultName, List<String> defaultLore) {
+        Material material = defaultMaterial;
+        String name = defaultName;
+        List<String> lore = defaultLore;
+
+        if (itemSection != null) {
+            String materialName = itemSection.getString("material");
+            if (materialName != null && !materialName.isEmpty()) {
+                Material configured = Material.matchMaterial(materialName.toUpperCase(Locale.ROOT));
+                if (configured != null) {
+                    material = configured;
+                } else {
+                    logger.warning("Invalid material '" + materialName + "' configured at " + path + ".material. Using " + defaultMaterial + ".");
+                }
+            }
+            name = itemSection.getString("name", name);
+            List<String> configuredLore = itemSection.getStringList("lore");
+            if (!configuredLore.isEmpty()) {
+                lore = configuredLore;
+            }
+        }
+
+        ItemStack item = new ItemStack(material);
+        ItemMeta meta = item.getItemMeta();
+        meta.displayName(LEGACY_SERIALIZER.deserialize(name));
+        if (lore != null && !lore.isEmpty()) {
+            meta.lore(lore.stream().map(LEGACY_SERIALIZER::deserialize).toList());
+        }
+        item.setItemMeta(meta);
+        return item;
+    }
+
+    private ItemStack createBackItem(ConfigurationSection selectionSection) {
+        ConfigurationSection backSection = selectionSection == null ? null : selectionSection.getConfigurationSection("back-item");
+        Material material = Material.ARROW;
+        String name = "&cBack";
+        List<String> lore = new ArrayList<>();
+        if (backSection != null) {
+            String materialName = backSection.getString("material");
+            if (materialName != null && !materialName.isEmpty()) {
+                Material configured = Material.matchMaterial(materialName.toUpperCase(Locale.ROOT));
+                if (configured != null) {
+                    material = configured;
+                } else {
+                    logger.warning("Invalid material '" + materialName + "' configured at menu.selection.back-item.material. Using ARROW.");
+                }
+            }
+            name = backSection.getString("name", name);
+            List<String> configuredLore = backSection.getStringList("lore");
+            if (!configuredLore.isEmpty()) {
+                lore = configuredLore;
+            }
+        }
+
+        ItemStack item = new ItemStack(material);
+        ItemMeta meta = item.getItemMeta();
+        meta.displayName(LEGACY_SERIALIZER.deserialize(name));
+        if (!lore.isEmpty()) {
+            meta.lore(lore.stream().map(LEGACY_SERIALIZER::deserialize).toList());
+        }
+        item.setItemMeta(meta);
+        return item;
+    }
+
+    private ItemStack createEmptyPlaceholder(ConfigurationSection selectionSection) {
+        ConfigurationSection emptySection = selectionSection == null ? null : selectionSection.getConfigurationSection("empty");
+        Material material = Material.BARRIER;
+        String name = "&cNo messages available";
+        List<String> lore = List.of("&7You do not have access to any messages.");
+        if (emptySection != null) {
+            String materialName = emptySection.getString("material");
+            if (materialName != null && !materialName.isEmpty()) {
+                Material configured = Material.matchMaterial(materialName.toUpperCase(Locale.ROOT));
+                if (configured != null) {
+                    material = configured;
+                } else {
+                    logger.warning("Invalid material '" + materialName + "' configured at menu.selection.empty.material. Using BARRIER.");
+                }
+            }
+            name = emptySection.getString("name", name);
+            List<String> configuredLore = emptySection.getStringList("lore");
+            if (!configuredLore.isEmpty()) {
+                lore = configuredLore;
+            }
+        }
+
+        ItemStack item = new ItemStack(material);
+        ItemMeta meta = item.getItemMeta();
+        meta.displayName(LEGACY_SERIALIZER.deserialize(name));
+        if (lore != null && !lore.isEmpty()) {
+            meta.lore(lore.stream().map(LEGACY_SERIALIZER::deserialize).toList());
+        }
+        item.setItemMeta(meta);
+        return item;
+    }
+
+    private void applyAction(ItemStack item, String action) {
+        ItemMeta meta = item.getItemMeta();
+        meta.getPersistentDataContainer().set(actionKey, PersistentDataType.STRING, action);
+        item.setItemMeta(meta);
+    }
+
+    private String getString(ConfigurationSection section, String path, String def) {
+        if (section == null) {
+            return def;
+        }
+        return section.getString(path, def);
+    }
+
+    private int resolveItemSlot(int inventorySize, ConfigurationSection itemsSection, String key, int fallback, Set<Integer> usedSlots) {
+        if (itemsSection == null) {
+            return fallbackRootSlot(inventorySize, fallback, usedSlots);
+        }
+        ConfigurationSection itemSection = itemsSection.getConfigurationSection(key);
+        if (itemSection == null) {
+            return fallbackRootSlot(inventorySize, fallback, usedSlots);
+        }
+        boolean explicit = itemSection.isSet("slot");
+        int configured = itemSection.getInt("slot", fallback);
+        int slot = clampSlot(inventorySize, configured);
+        if (slot == -1 && explicit) {
+            logger.warning("Configured slot 'menu.root.items." + key + ".slot' is outside the menu size of " + inventorySize + ". Using fallback.");
+        }
+        if (slot == -1) {
+            slot = clampSlot(inventorySize, fallback);
+        }
+        if (slot == -1) {
+            slot = findNextAvailableSlot(inventorySize, usedSlots);
+        }
+        if (slot >= 0 && usedSlots.contains(slot)) {
+            logger.warning("Configured slot 'menu.root.items." + key + ".slot' is already occupied. Searching for another slot.");
+            slot = findNextAvailableSlot(inventorySize, usedSlots);
+        }
+        return slot;
+    }
+
+    private int fallbackRootSlot(int inventorySize, int fallback, Set<Integer> usedSlots) {
+        int slot = clampSlot(inventorySize, fallback);
+        if (slot == -1) {
+            slot = findNextAvailableSlot(inventorySize, usedSlots);
+        }
+        if (slot >= 0 && usedSlots.contains(slot)) {
+            slot = findNextAvailableSlot(inventorySize, usedSlots);
+        }
+        return slot;
+    }
+
+    private int resolveSlot(ConfigurationSection section, int inventorySize, String path, int fallback) {
+        int configured = fallback;
+        boolean explicit = section != null && section.isSet(path);
+        if (section != null && section.isInt(path)) {
+            configured = section.getInt(path, fallback);
+        }
+        int slot = clampSlot(inventorySize, configured);
+        if (slot == -1 && explicit) {
+            logger.warning("Configured slot 'menu.selection." + path + "' is outside the menu size of " + inventorySize + ". Using fallback.");
+        }
+        if (slot == -1) {
+            if (inventorySize > 0) {
+                int sanitized = Math.min(Math.max(fallback, 0), inventorySize - 1);
+                slot = clampSlot(inventorySize, sanitized);
+            }
+        }
+        return slot;
+    }
+
+    private int clampSlot(int inventorySize, int slot) {
+        if (inventorySize <= 0) {
+            return -1;
+        }
+        if (slot < 0 || slot >= inventorySize) {
+            return -1;
+        }
+        return slot;
+    }
+
+    private int resolveInventorySize(ConfigurationSection section, int fallback) {
+        int size = fallback;
+        boolean explicit = section != null && section.isSet("size");
+        if (section != null && section.isInt("size")) {
+            size = section.getInt("size", fallback);
+        }
+        int original = size;
+        if (size < 9) {
+            size = 9;
+        }
+        if (size > 54) {
+            size = 54;
+        }
+        if (size % 9 != 0) {
+            size = ((size / 9) + 1) * 9;
+            if (size > 54) {
+                size = 54;
+            }
+        }
+        if (explicit && size != original) {
+            logger.warning("Adjusted inventory size from " + original + " to " + size + " to satisfy inventory constraints.");
+        }
+        return size;
+    }
+
+    private List<Integer> getConfiguredSlots(ConfigurationSection selectionSection) {
+        if (selectionSection == null) {
+            return List.of();
+        }
+        List<Integer> slots = selectionSection.getIntegerList("option-slots");
+        if (slots == null || slots.isEmpty()) {
+            return List.of();
+        }
+        List<Integer> normalized = new ArrayList<>();
+        for (Integer slot : slots) {
+            if (slot != null) {
+                normalized.add(slot);
+            }
+        }
+        return normalized;
+    }
+
+    private int resolveOptionSlot(int index, List<Integer> configuredSlots, int size, Set<Integer> usedSlots, Set<Integer> reservedSlots) {
+        if (index < configuredSlots.size()) {
+            int configured = configuredSlots.get(index);
+            if (configured >= 0 && configured < size && !usedSlots.contains(configured) && !reservedSlots.contains(configured)) {
+                return configured;
+            }
+            logger.warning("Configured slot 'menu.selection.option-slots[" + index + "]' is not available in the current menu.");
+        }
+        for (int i = 0; i < size; i++) {
+            if (!usedSlots.contains(i) && !reservedSlots.contains(i)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private int findNextAvailableSlot(int size, Set<Integer> usedSlots) {
+        for (int i = 0; i < size; i++) {
+            if (!usedSlots.contains(i)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+}

--- a/src/main/java/me/minimize/NexoJoin/menu/MenuView.java
+++ b/src/main/java/me/minimize/NexoJoin/menu/MenuView.java
@@ -1,0 +1,6 @@
+package me.minimize.NexoJoin.menu;
+
+public enum MenuView {
+    ROOT,
+    SELECTION
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,81 @@
+menu:
+  root:
+    title: "&9Nexo Messages"
+    size: 27
+    items:
+      join:
+        slot: 11
+        material: "LIME_DYE"
+        name: "&aJoin Messages"
+        lore:
+          - "&7Select your join message."
+      leave:
+        slot: 15
+        material: "RED_DYE"
+        name: "&cLeave Messages"
+        lore:
+          - "&7Select your leave message."
+  selection:
+    size: 54
+    option-slots:
+      - 10
+      - 11
+      - 12
+      - 19
+      - 20
+      - 21
+      - 28
+      - 29
+      - 30
+      - 37
+      - 38
+      - 39
+    join:
+      title: "&aJoin Messages"
+    leave:
+      title: "&cLeave Messages"
+    back-item:
+      slot: 49
+      material: "ARROW"
+      name: "&cBack"
+      lore:
+        - "&7Click to return to the main menu."
+    empty:
+      slot: 22
+      material: "BARRIER"
+      name: "&cNo messages available"
+      lore:
+        - "&7You do not have access to any messages."
+defaults:
+  join: default
+  leave: default
+join-messages:
+  default:
+    display-name: "&aDefault Welcome"
+    message: "&7%player% joined the server."
+    material: "EMERALD"
+    lore:
+      - "&7The classic join announcement."
+    permission: ""
+  vip:
+    display-name: "&6VIP Arrival"
+    message: "&6%player% &7has arrived!"
+    material: "GOLD_INGOT"
+    lore:
+      - "&7Show off that you're special."
+    permission: "nexojoin.join.vip"
+leave-messages:
+  default:
+    display-name: "&aDefault Goodbye"
+    message: "&7%player% left the server."
+    material: "OAK_DOOR"
+    lore:
+      - "&7Simple and clean."
+    permission: ""
+  stealth:
+    display-name: "&8Silent Exit"
+    message: "&8%player% &7vanished into the shadows."
+    material: "ENDER_PEARL"
+    lore:
+      - "&7Perfect for sneaking away."
+    permission: "nexojoin.leave.stealth"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,16 @@
+name: NexoJoin
+version: 1.0.0
+main: me.minimize.NexoJoin.NexoJoinPlugin
+api-version: 1.21
+commands:
+  joinmessages:
+    description: Open the join and leave message selector.
+    aliases: [messages]
+    permission: nexojoin.command
+permissions:
+  nexojoin.command:
+    description: Allows players to open the message selection menu.
+    default: true
+  nexojoin.reload:
+    description: Allows reloading the plugin configuration.
+    default: op


### PR DESCRIPTION
## Summary
- ensure stored selections are cleared when players lose access and fall back to permitted defaults during join/quit handling
- stop assigning the first configured option without permission checks and clean invalid menu selections and player data entries
- document the end-to-end plugin flow and safeguards that prevent players from exploiting join/leave messages
- cancel drag events in custom menus so players cannot extract interface items

## Testing
- `mvn -q package` *(fails: unable to download Maven resources plugin because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ca8e3f51f0832da14b79aed56df84f