### PR TITLE
Switch to Paper API dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,17 +14,24 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spigot.api.version>1.21.1-R0.1-SNAPSHOT</spigot.api.version>
+        <paper.api.version>1.21.1-R0.1-SNAPSHOT</paper.api.version>
     </properties>
 
     <dependencies>
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
-            <version>${spigot.api.version}</version>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>${paper.api.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
+
+    <repositories>
+        <repository>
+            <id>papermc</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
+    </repositories>
 
     <build>
         <plugins>


### PR DESCRIPTION
## Summary
- replace the Spigot API dependency with the Paper API and update the version property
- add the PaperMC Maven repository so the Paper API artifact can be resolved

## Testing
- `mvn clean package` *(fails: network is unreachable while downloading maven-clean-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68ca9a048b2c832d807a6192ce88b9a5