### PR TITLE
Fix lambda selection check for menu

### DIFF
--- a/src/main/java/me/minimize/NexoJoin/menu/MenuService.java
+++ b/src/main/java/me/minimize/NexoJoin/menu/MenuService.java
@@ -105,7 +105,8 @@ public class MenuService {
 
         List<MessageOption> options = messageManager.getAvailable(player, type);
         String selectedId = playerDataManager.getSelectedMessageId(player.getUniqueId(), type);
-        boolean hasSelection = selectedId != null && options.stream().anyMatch(option -> option.getId().equalsIgnoreCase(selectedId));
+        String currentSelectedId = selectedId;
+        boolean hasSelection = currentSelectedId != null && options.stream().anyMatch(option -> option.getId().equalsIgnoreCase(currentSelectedId));
         if (!hasSelection) {
             if (!options.isEmpty()) {
                 MessageOption first = options.get(0);


### PR DESCRIPTION
## Summary
- ensure the selected message id used within the selection menu lambda is captured by an effectively final variable to satisfy Java's lambda requirements

## Testing
- `mvn -q compile` *(fails: unable to resolve maven-resources-plugin due to network restrictions in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca9c1b7380832da64ec210bc37509f