### PR TITLE
Fix menu text styling and hide permission lore

### DIFF
--- a/src/main/java/me/minimize/NexoJoin/MessageOption.java
+++ b/src/main/java/me/minimize/NexoJoin/MessageOption.java
@@ -1,6 +1,7 @@
 package me.minimize.NexoJoin;
 
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -8,11 +9,11 @@ import org.bukkit.entity.Player;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.Objects;
 
 public class MessageOption {
     private static final LegacyComponentSerializer LEGACY_SERIALIZER = LegacyComponentSerializer.legacyAmpersand();
+    private static final Component EMPTY_LINE = Component.empty().decoration(TextDecoration.ITALIC, false);
 
     private final String id;
     private final String displayName;
@@ -59,32 +60,26 @@ public class MessageOption {
     }
 
     public Component asDisplayComponent() {
-        return LEGACY_SERIALIZER.deserialize(displayName);
+        return deserializeNonItalic(displayName);
     }
 
     public List<Component> buildLore(boolean selected) {
         List<Component> components = new ArrayList<>();
         for (String line : lore) {
-            components.add(LEGACY_SERIALIZER.deserialize(line));
+            components.add(deserializeNonItalic(line));
         }
         if (!message.isEmpty()) {
             if (!components.isEmpty()) {
-                components.add(Component.empty());
+                components.add(EMPTY_LINE);
             }
-            components.add(LEGACY_SERIALIZER.deserialize("&7Preview:"));
-            components.add(LEGACY_SERIALIZER.deserialize("&f" + message.replace("%player%", "Player").replace("%displayname%", "Player")));
+            components.add(deserializeNonItalic("&7Preview:"));
+            components.add(deserializeNonItalic("&f" + message.replace("%player%", "Player").replace("%displayname%", "Player")));
         }
         if (selected) {
             if (!components.isEmpty()) {
-                components.add(Component.empty());
+                components.add(EMPTY_LINE);
             }
-            components.add(LEGACY_SERIALIZER.deserialize("&aCurrently selected"));
-        }
-        if (!permission.isEmpty()) {
-            if (!components.isEmpty()) {
-                components.add(Component.empty());
-            }
-            components.add(LEGACY_SERIALIZER.deserialize("&7Permission: &f" + permission.toLowerCase(Locale.ROOT)));
+            components.add(deserializeNonItalic("&aCurrently selected"));
         }
         return components;
     }
@@ -96,6 +91,10 @@ public class MessageOption {
         String formatted = message
                 .replace("%player%", player.getName())
                 .replace("%displayname%", player.getDisplayName());
-        return LEGACY_SERIALIZER.deserialize(formatted);
+        return deserializeNonItalic(formatted);
+    }
+
+    private Component deserializeNonItalic(String input) {
+        return LEGACY_SERIALIZER.deserialize(input).decoration(TextDecoration.ITALIC, false);
     }
 }

--- a/src/main/java/me/minimize/NexoJoin/menu/MenuService.java
+++ b/src/main/java/me/minimize/NexoJoin/menu/MenuService.java
@@ -5,6 +5,8 @@ import me.minimize.NexoJoin.MessageOption;
 import me.minimize.NexoJoin.MessageType;
 import me.minimize.NexoJoin.NexoJoinPlugin;
 import me.minimize.NexoJoin.PlayerDataManager;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -197,9 +199,9 @@ public class MenuService {
 
         ItemStack item = new ItemStack(material);
         ItemMeta meta = item.getItemMeta();
-        meta.displayName(LEGACY_SERIALIZER.deserialize(name));
+        meta.displayName(deserializeNonItalic(name));
         if (lore != null && !lore.isEmpty()) {
-            meta.lore(lore.stream().map(LEGACY_SERIALIZER::deserialize).toList());
+            meta.lore(lore.stream().map(this::deserializeNonItalic).toList());
         }
         item.setItemMeta(meta);
         return item;
@@ -229,9 +231,9 @@ public class MenuService {
 
         ItemStack item = new ItemStack(material);
         ItemMeta meta = item.getItemMeta();
-        meta.displayName(LEGACY_SERIALIZER.deserialize(name));
+        meta.displayName(deserializeNonItalic(name));
         if (!lore.isEmpty()) {
-            meta.lore(lore.stream().map(LEGACY_SERIALIZER::deserialize).toList());
+            meta.lore(lore.stream().map(this::deserializeNonItalic).toList());
         }
         item.setItemMeta(meta);
         return item;
@@ -261,9 +263,9 @@ public class MenuService {
 
         ItemStack item = new ItemStack(material);
         ItemMeta meta = item.getItemMeta();
-        meta.displayName(LEGACY_SERIALIZER.deserialize(name));
+        meta.displayName(deserializeNonItalic(name));
         if (lore != null && !lore.isEmpty()) {
-            meta.lore(lore.stream().map(LEGACY_SERIALIZER::deserialize).toList());
+            meta.lore(lore.stream().map(this::deserializeNonItalic).toList());
         }
         item.setItemMeta(meta);
         return item;
@@ -273,6 +275,10 @@ public class MenuService {
         ItemMeta meta = item.getItemMeta();
         meta.getPersistentDataContainer().set(actionKey, PersistentDataType.STRING, action);
         item.setItemMeta(meta);
+    }
+
+    private Component deserializeNonItalic(String input) {
+        return LEGACY_SERIALIZER.deserialize(input).decoration(TextDecoration.ITALIC, false);
     }
 
     private String getString(ConfigurationSection section, String path, String def) {


### PR DESCRIPTION
## Summary
- disable automatic italic styling for menu names, lore, and previews so the menu renders with normal text
- remove the permission line from message option lore to declutter the menu
- ensure configured root/back/empty items are also deserialized with italics disabled

## Testing
- `mvn -q -DskipTests package` *(fails: network is unreachable while downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68caa2820618832d8fa6001ebeaa5f9f